### PR TITLE
Do not cut the last char of the host not containing a new line

### DIFF
--- a/common.c
+++ b/common.c
@@ -33,7 +33,11 @@ ssize_t ts_get_line_input(input_handle_t *handle, char *line, size_t len)
   }
 
   while ((read = getline(&line, &len, handle->fp)) != -1) {
-    line[read - 1] = 0;
+    // zero-terminate only new lines
+    if (line[read - 1] == '\n') {
+      line[read - 1] = 0;
+    }
+
     // skip empty lines
     if (read > 0)
       break;


### PR DESCRIPTION
This one fixes hostname parsing when it's passed without a new line, e.g.:

```shell
$ echo -n openbsd.org | tls-scan --port 443
```

or when input stream doesn't have a new line either:

```shell
$ cat hostlist.txt | tls-scan --port 443
```

otherwise we get:

```
host: openbsd.or; ip: ; error: DNS; errormsg: nodename nor servname provided, or not known
```