### PR TITLE
Fix Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,31 @@
+FROM ubuntu:16.04 AS builder
+
+RUN set -xeu; \
+    apt-get update; \
+    apt-get upgrade; \
+    apt-get install -y \
+        build-essential \
+        autoconf \
+        automake \
+        pkg-config \
+        curl \
+        zip \
+        libtool
+
+COPY . /usr/local/src/tls-scan
+RUN set -xeu; \
+    cd /usr/local/src/tls-scan; \
+    ./build-x86-64.sh
+
+
 FROM ubuntu:16.04
 
-RUN apt-get update -y
-RUN apt-get upgrade -y
+RUN useradd -rU tls-scan
+USER tls-scan
 
-RUN apt-get install build-essential -y
-RUN apt-get install curl -y
-RUN apt-get install zip -y
-RUN apt-get install autoconf -y
-RUN apt-get install libtool -y
-RUN apt-get install automake -y
-RUN apt-get install pkg-config -y
-RUN apt-get install jq -y
-
-ENV TS_INSTALLDIR /usr/local
-ADD ./build-x86-64.sh build-x86-64.sh
-RUN ./build-x86-64.sh
+WORKDIR /usr/local/share/tls-scan/
+COPY --from=builder /usr/local/src/tls-scan/build-root/bin/tls-scan /usr/local/bin/tls-scan
+ADD --chown=tls-scan:tls-scan https://curl.haxx.se/ca/cacert.pem ./ca-bundle.crt
 
 ENTRYPOINT ["tls-scan"]
 CMD ["--help"]
-

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Copy the [Dockerfile](https://github.com/prbinu/tls-scan/blob/master/Dockerfile)
 *Test* :
 
 ```sh
-% docker run tls-scan --connect=yahoo.com:443 --cacert=/usr/local/etc/tls-scan/ca-bundle.crt --pretty
+% docker run --rm tls-scan --connect=example.com:443 --all --pretty
 ```
 
 ## Example


### PR DESCRIPTION
Dockerfile didn't build because only `build-x86-64.sh` was copied to an image without a source code. This was fixed, plus some changes were made:

- `builder` stage used to reduce resulting image size
- multiple `RUN`'s merged to reduce number of layers
- the newest certificate bundle is downloaded from `curl.haxx.se` for better validation
- non-privileged user `tls-scan` is created to run the tool
- `README.md` usage example updated