### PR TITLE
Upgrade zlib version in bootstrap.sh

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -45,7 +45,7 @@ export PKG_CONFIG_PATH=${OUTDIR}/lib/pkgconfig
 
 OPENSSL_VERSION="1.0.2-chacha"
 LIBEVENT_VERSION="2.1.8-stable"
-ZLIB_VERSION="zlib-1.2.11"
+ZLIB_VERSION="zlib-1.2.12"
 
 FILE="${BUILDDIR}/downloads/${OPENSSL_VERSION}.zip"
 if [ ! -f $FILE ]; then


### PR DESCRIPTION
Upgrading zlib version to 1.2.12 in bootstrap.sh (zlib-1.2.11 is unavailable)
http://www.zlib.net/zlib-1.2.11.tar.gz not found