### PR TITLE
Update bootstrap to use current zlib

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -45,7 +45,7 @@ export PKG_CONFIG_PATH=${OUTDIR}/lib/pkgconfig
 
 OPENSSL_VERSION="1.0.2-chacha"
 LIBEVENT_VERSION="2.1.8-stable"
-ZLIB_VERSION="zlib-1.2.12"
+ZLIB_VERSION="zlib-1.2.13"
 
 FILE="${BUILDDIR}/downloads/${OPENSSL_VERSION}.zip"
 if [ ! -f $FILE ]; then


### PR DESCRIPTION
zlib-1.2.12.zip is no longer available because of CVE-2022-37434